### PR TITLE
Video call when near by

### DIFF
--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -28,7 +28,6 @@ module.exports = (io) => {
     socket.on("closeBy", (data) => {
       const { roomKey, playerId } = data;
       const roomInfo = gameRooms[roomKey];
-      console.log(roomInfo.players)
       io.to(playerId).emit("videoCall", {
         playerInfo: roomInfo.players[socket.id],
       });
@@ -37,7 +36,6 @@ module.exports = (io) => {
     socket.on("farAway", (data)=>{
       const { roomKey, playerId } = data;
       const roomInfo = gameRooms[roomKey];
-      console.log(roomInfo.players)
       io.to(playerId).emit("stopCall", {
         playerInfo: roomInfo.players[socket.id],
       });

--- a/src/scenes/waiting-room.js
+++ b/src/scenes/waiting-room.js
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import { openVideo } from "../video-client";
 
 export default class WaitingRoom extends Phaser.Scene {
   constructor() {
@@ -9,7 +10,7 @@ export default class WaitingRoom extends Phaser.Scene {
 
   init(data) {
     this.socket = data.socket;
-    this.peerId = data.peerId;
+    this.myPeer = data.myPeer;
   }
 
   preload() {
@@ -96,9 +97,11 @@ export default class WaitingRoom extends Phaser.Scene {
       scene.notValidText.setText("Invalid Room Key");
     });
     scene.socket.on("keyIsValid", (data) => {
-      data.peerId = this.peerId;
+      data.peerId = this.myPeer.id;
       scene.socket.emit("joinRoom", data);
       scene.scene.stop("WaitingRoom");
+      // open video
+      openVideo(scene.socket, this.myPeer)
     });
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,4 @@
+export function closeEnough(positionA, positionB) {
+    const distance = Math.sqrt((positionA.x - positionB.x) ** 2 + (positionA.y - positionB.y) ** 2)
+    return distance < 50;
+}

--- a/src/video-client.js
+++ b/src/video-client.js
@@ -1,10 +1,3 @@
-// socket connect to root path of localhost
-import Peer from "peerjs";
-
-// const socket = io("/");
-
-// const myPeer = new Peer();
-
 const videoGrid = document.getElementById("video-grid");
 
 const myVideo = document.createElement("video");
@@ -46,27 +39,40 @@ export function openVideo(socket, myPeer) {
         });
       });
 
-      socket.on("newPlayer", (userData) => {
+      socket.on("videoCall", (userData) => {
         console.log(userData);
         const { playerInfo: { peerId } } = userData;
-        console.log("newPlayer: ", peerId);
+        console.log("videoCall: ", peerId);
         connectToNewUser(myPeer, peerId, stream);
       });
 
       socket.on("disconnected", (userData) => {
-        const { playerInfo: { peerId } } = userData;
+        const { peerId } = userData;
         console.log("disconnected: ", peerId);
       
         if (peers[peerId]) {
-          peers[userId].close();
+          peers[peerId].close();
+        }
+      });
+
+      socket.on("stopCall", (userData) => {
+        const { playerInfo: { peerId } } = userData;
+        console.log("stopCall: ", peerId);
+      
+        if (peers[peerId]) {
+          peers[peerId].close();
         }
       });
     });
 }
 
-// myPeer.on("open", (id) => {
-//   socket.emit("join-room", ROOM_ID, id);
-// });
+export function stopVideo(peerId) {
+  console.log("stop video: ", peerId)
+  if (peers[peerId]) {
+    console.log("stop video...")
+    peers[peerId].close();
+  }
+}
 
 /**
  * make calls when new user connect to our room


### PR DESCRIPTION
I have changed the video call logic. The video will not open when the game is loaded. It will start video for the current user when user join the room. When two users get close to each other. It will start video chat. 

I did some test and it works well for two players. It is pretty buggy when three players are involved. I always saw socket disconnect issue. Maybe, it is too heavy to communicate socket event and webRTC call among multiple players?

