### PR TITLE
add iframe to whiteboard app with toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,12 +25,41 @@
             height: 100px;
             object-fit: cover;
         }
+        body {
+            display: grid;
+            grid-template-columns: 60% 40%;
+        }
+        iframe {
+            position: absolute;
+            right: 0;
+            height: 100%;
+            width: 30vw;
+        }
+
+        .hidden {
+            position: absolute;
+            width:0;
+            height:0;
+            border:0;
+        }
     </style>
+    <script>
+        document.onkeypress = function (e) {
+        e = e || window.event;
+        if (e.keyCode==13) {
+            var iframe = document.getElementById('whiteboard')
+            iframe.classList.toggle("hidden");
+        }     
+    };
+    </script>
 </head>
 
 <body>
     <div id="game"></div>
     <div id="video-grid"></div>
+    <iframe id="whiteboard" src="http://localhost:3000/100" sandbox="allow-same-origin allow-popups allow-scripts" title="question interface" vis></iframe>
+    
 </body>
+
 
 </html>


### PR DESCRIPTION
<img width="1152" alt="Screen Shot 2021-12-30 at 2 07 27 PM" src="https://user-images.githubusercontent.com/60363909/147781214-94768554-deba-4bae-948a-a0b7b0b03862.png">


added iframe to whiteboard on http://localhost:3000/100
(you must also be running Ryans' [whiteboard app](https://github.com/SMARTeacher/app-tutoring-whiteboard) locally.)
if you go to [room `100`](http://localhost:3000/100) you can see the other side of the socket 
added a toggle (press enter) to show/hide whiteboard